### PR TITLE
Memory corruption + surrogates fix

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -907,9 +907,9 @@ json_fini(JSON_PARSER* parser, JSON_INPUT_POS* p_pos)
     }
 
     free(parser->nesting_stack);
-    parser->nesting_stack = nullptr;
+    parser->nesting_stack = NULL;
     free(parser->buf);
-    parser->buf = nullptr;
+    parser->buf = NULL;
     return parser->errcode;
 }
 

--- a/src/json.c
+++ b/src/json.c
@@ -638,6 +638,7 @@ json_string_automaton(JSON_PARSER* parser, const char* input, size_t size,
             if(ch == 'u') {
                 /* Expecting 4 hex digits. */
                 parser->substate = 0xabcd + 4;
+                parser->codepoint[0] = parser->codepoint[1] = 0;
             } else {
                 switch(ch) {
                     case '\"':  ch = '\"'; break;

--- a/src/json.c
+++ b/src/json.c
@@ -908,7 +908,9 @@ json_fini(JSON_PARSER* parser, JSON_INPUT_POS* p_pos)
     }
 
     free(parser->nesting_stack);
+    parser->nesting_stack = nullptr;
     free(parser->buf);
+    parser->buf = nullptr;
     return parser->errcode;
 }
 


### PR DESCRIPTION
Multiple surrogates in a string causing parser to throw error, fix: reset codepoints before entering /u escape parsing state.

Calling json_fini on a single parser object causing memory corruption, fix: set pointers to NULL after freeing.